### PR TITLE
Fix faulty input validation

### DIFF
--- a/limo_cluster_functions/limo_cluster_correction.m
+++ b/limo_cluster_functions/limo_cluster_correction.m
@@ -49,7 +49,7 @@ mask = cluster_p;
 
 %% compute cluster mass
 ndim = numel(size(bootM));
-if ndim ~=3 || ndim ~= 4
+if ndim ~= 3 && ndim ~= 4
     error('H0 data must be 3D or 4D')
 end
 


### PR DESCRIPTION
First off, thank you for this great toolbox! It's really helping me through my Master thesis.
I have encountered this issue when  plugging in a 3-dimensional bootM matrix into `limo_cluster_correction`.
Perhaps I am just misusing the function. Please let me know if that's the case.

# Expected behaviour
Error should be thrown if ndim is *neither* 3 nor 4.

# Actual behaviour
Error is thrown if ndim is not 3 and 4 at the same time.

# Fix
I think the logic of the original issue goes as follow:

Given `ndim = 3`
if ndim != 3 (which evaluates to false, since ndim *is* 3), check whether ndim != 4. The second comparison evaluates to true, since dim = 3. In turn, the OR operator evaluates to true and the error is thrown.