### PR TITLE
Fix faulty input validation

### DIFF
--- a/limo_cluster_functions/limo_cluster_correction.m
+++ b/limo_cluster_functions/limo_cluster_correction.m
@@ -49,7 +49,7 @@ mask = cluster_p;
 
 %% compute cluster mass
 ndim = numel(size(bootM));
-if ndim ~= 3 && ndim ~= 4
+if ndim < 3 
     error('H0 data must be 3D or 4D')
 end
 

--- a/limo_cluster_functions/limo_cluster_correction.m
+++ b/limo_cluster_functions/limo_cluster_correction.m
@@ -49,7 +49,7 @@ mask = cluster_p;
 
 %% compute cluster mass
 ndim = numel(size(bootM));
-if ndim ~=3 || ndim ~= 4
+if ndim ~= 3 && ndim ~= 4
     error('H0 data must be 3D or 4D')
 end
 


### PR DESCRIPTION
Same as original pull request, changed to HotFixes branch.

I have encountered this issue when  plugging in a 3-dimensional bootM matrix.

Expected behavior: Error should be thrown if ndim is *neither* 3 nor 4.
Actual behavior: Error is thrown is ndim is not 3 and 4 at the same time.

I think the logic of the original issue goes as follow:

Given `ndim = 3`
if ndim != 3 (which evaluates to false, since ndim *is* 3), check whether ndim != 4. The second comparison evaluates to true, since dim = 3. The OR operator evaluates to true then and the error is thrown.