### PR TITLE
Update limo_display_results.m

### DIFF
--- a/limo_display_results.m
+++ b/limo_display_results.m
@@ -71,9 +71,9 @@ end
 choice = 'use theoretical p values'; % threshold based on what is computed since H0 is used for clustering
 % see limo_stat_values - discontinuated empirical threshold (misleading)
 
+% Load LIMO structure if a path was provided
 if ischar(LIMO)
-    LIMO = load(LIMO);
-    LIMO = LIMO.LIMO;
+    load(LIMO, 'LIMO');
 end
 
 if LIMO.design.bootstrap == 0


### PR DESCRIPTION
Load the LIMO structure directly, rather than loading a struct that contains it as a field, then pulling that field.