### PR TITLE
Fix typos in error messages

### DIFF
--- a/limo_get_channeighbstructmat.m
+++ b/limo_get_channeighbstructmat.m
@@ -29,7 +29,7 @@ function [neighbours,channeighbstructmat] = limo_get_channeighbstructmat(EEG,nei
 %  Copyright (C) LIMO Team 2019
 
 if nargin < 2
-    error('missing inpouts')
+    error('missing inputs')
 end
 
 if isempty(EEG.chanlocs) || isfield(EEG,'chanlocs') == 0

--- a/limo_get_effect_size.m
+++ b/limo_get_effect_size.m
@@ -78,7 +78,7 @@ if ~exist(fullfile(filepath,filename),'file')
 end
 
 if ~exist(fullfile(filepath,'LIMO.mat'),'file')
-    error('cannot find a LIMO.mat in the same filder as this file, this is required for this function to work')
+    error('cannot find a LIMO.mat in the same folder as this file, this is required for this function to work')
 else
     LIMO = load(fullfile(filepath,'LIMO.mat'));
     LIMO = LIMO.LIMO;

--- a/limo_get_summary.m
+++ b/limo_get_summary.m
@@ -55,7 +55,7 @@ if ~exist(fullfile(filepath,filename),'file')
 end
 
 if ~exist(fullfile(filepath,'LIMO.mat'),'file')
-    error('cannot find a LIMO.mat in the same filder as this file, this is required for this function to work')
+    error('cannot find a LIMO.mat in the same folder as this file, this is required for this function to work')
 else
     LIMO = load(fullfile(filepath,'LIMO.mat'));
     LIMO = LIMO.LIMO;


### PR DESCRIPTION
## Summary
- correct typo in `limo_get_channeighbstructmat` error
- fix 'filder' typo in error messages in `limo_get_summary` and `limo_get_effect_size`

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_685d401ab64c83258fb1e937109b8519