### PR TITLE
Fix figure handle usage for MATLAB 2025

### DIFF
--- a/limo_BrownForsythe.m
+++ b/limo_BrownForsythe.m
@@ -88,7 +88,7 @@ if nargout == 0
    save('BrownForsythe_test.mat','dataout','-v7.3') 
 end
 
-figure;
+hfig = figure;
 mask = (squeeze(dataout(:,:,2)) <= 0.05);
 toplot = squeeze(dataout(:,:,1));
 imagesc(toplot.*mask);
@@ -96,7 +96,7 @@ xlabel('frames'); ylabel('channels')
 toplot(mask==0)=NaN;
 colormap(limo_color_images(toplot))
 title('Variance Homogeneity test')
-drawnow; saveas(gcf, 'BrownForsythe','fig'); close(gcf)
+drawnow; saveas(hfig, 'BrownForsythe','fig'); close(hfig)
 
 
 

--- a/limo_LI.m
+++ b/limo_LI.m
@@ -244,7 +244,7 @@ end
 
 %% figure
 if strcmpi(fig_option,'on')
-    figure;
+    hfig = figure;
     subplot(3,6,1:12); plot(LI_stats.thresholds,LI_stats.LI,'LineWidth',3); grid on; box on
     xlabel('TFCE thresholds'); ylabel('lateralization index'); ax = get(gca);
     if length(LI_stats.mean) == 1

--- a/limo_STAPLE.m
+++ b/limo_STAPLE.m
@@ -142,5 +142,6 @@ for cluster = max(nclusters):-1:1
 end
 staple_thmap = sum(all_maps,ndims(all_maps));
 save(fullfile(pwd,'staple_thmap_labelled.mat'),'staple_thmap')
-figure; imagesc(staple_thmap);
+hfig = figure;
+imagesc(staple_thmap);
 title('Binary STAPLE map')

--- a/limo_display_image.m
+++ b/limo_display_image.m
@@ -181,7 +181,8 @@ end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% make the main figure
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-figure; set(gcf,'Color','w','InvertHardCopy','off');
+hfig = figure;
+set(hfig,'Color','w','InvertHardCopy','off');
 
 % course plot at best electrode
 ax(3) = subplot(3,3,9);

--- a/limo_display_image_tf.m
+++ b/limo_display_image_tf.m
@@ -419,8 +419,8 @@ function gifbutton_Callback(hObject, eventdata, handles)
 
 vidObj = VideoWriter(handles.title);
 open(vidObj);
-h=figure('Name',handles.title);
-set(gcf,'Color','w','InvertHardCopy','off', 'units','normalized', 'outerposition',[0 0 1 1]);
+h = figure('Name',handles.title);
+set(h,'Color','w','InvertHardCopy','off', 'units','normalized', 'outerposition',[0 0 1 1]);
 popup_sel_index = get(handles.pop_up_dimensions, 'Value');
 if popup_sel_index == 1  % if showing elec x freq
     for t=1:size(handles.scale,3)

--- a/limo_display_results.m
+++ b/limo_display_results.m
@@ -440,7 +440,8 @@ if LIMO.Level == 1
                         end
                     end
 
-                    figure; set(gcf,'Color','w');
+                    hfig = figure;
+                    set(hfig,'Color','w');
                     % imagesc eigen values
                     subplot(3,3,[4 5 7 8]);
                     timevect = linspace(LIMO.data.start,LIMO.data.end,size(EV,2));
@@ -491,7 +492,8 @@ if LIMO.Level == 1
                     k = LIMO.design.nb_conditions;
 
                     if k>2
-                        figure;set(gcf,'Color','w');
+                        hfig = figure;
+                        set(hfig,'Color','w');
                         subplot(2,2,[1 2]); % 2D plot of two discriminant functions
                         gscatter(squeeze(Discriminant_scores(1,t,:)), squeeze(Discriminant_scores(2,t,:)), class, groupcolors(1:k), groupsymbols(1:k));
                         grid on; axis tight;
@@ -507,7 +509,8 @@ if LIMO.Level == 1
                         topoplot(Discriminant_coeff(:,t,2),LIMO.data.chanlocs, 'electrodes','off','style','map','whitebk', 'on','colormap',cc);colorbar;
                         title('Z2','Fontsize',14); colormap(z2, 'hot');
                     elseif k==2
-                        figure;set(gcf,'Color','w');
+                        hfig = figure;
+                        set(hfig,'Color','w');
                         subplot(2,2,[1 2]); % 1D plot of two discriminant functions
                         data = squeeze(Discriminant_scores(1,t,:));
                         class1 = data(class == 1);
@@ -540,7 +543,8 @@ if LIMO.Level == 1
                     Linear_Classification = Linear_Classification.Linear_Classification;
                     [~, mask, mytitle] = limo_mstat_values(Type,FileName,p,MCC,LIMO,choice);
                     timevect = linspace(LIMO.data.start,LIMO.data.end,size(Linear_Classification,1));
-                    figure;set(gcf,'Color','w');
+                    hfig = figure;
+                    set(hfig,'Color','w');
                     subplot(3,1,[1 2]); % lineplot
                     plot(timevect,Linear_Classification(:,2),'LineWidth',3);title(mytitle, 'Fontsize', 18);
                     ylabel('decoding accuracies', 'Fontsize', 14);grid on; axis tight; hold on;
@@ -558,7 +562,8 @@ if LIMO.Level == 1
                     Quadratic_Classification = load(fullfile(LIMO.dir,'Quadratic_Classification'));
                     Quadratic_Classification = Quadratic_Classification.Quadratic_Classification;
                     timevect = linspace(LIMO.data.start,LIMO.data.end,size(Quadratic_Classification,1));
-                    figure;set(gcf,'Color','w');
+                    hfig = figure;
+                    set(hfig,'Color','w');
                     subplot(3,1,[1 2]); % lineplot
                     plot(timevect,Quadratic_Classification(:,2),'LineWidth',3);title('CV quadratic decoding accuracies +/- 2SD', 'Fontsize', 18);
                     ylabel('decoding accuracies', 'Fontsize', 14);grid on; axis tight; hold on
@@ -971,7 +976,8 @@ if LIMO.Level == 1
 
             % make the figure(s)
             % ------------------
-            figure;set(gcf,'Color','w')
+            hfig = figure;
+            set(hfig,'Color','w')
             if sum(regressor <= categorical) == length(regressor)
                 for i=1:size(average,1)
                     if i==1
@@ -1112,7 +1118,10 @@ if LIMO.Level == 1
 
             else
                 for i=1:size(continuous,1)
-                    if i > 1; figure;set(gcf,'Color','w'); end
+                    if i > 1
+                        hfig = figure;
+                        set(hfig,'Color','w');
+                    end
                     index = find(~isnan(squeeze(continuous(i,1,:))));
 
                     if strcmpi(LIMO.Analysis,'Frequency')
@@ -1335,7 +1344,8 @@ elseif LIMO.Level == 2
                             opt = {'maplimits','absmax','electrodes','off','verbose','off'};
                         end
                     end
-                    figure; set(gcf,'Color','w','InvertHardCopy','off');
+                    hfig = figure;
+                    set(hfig,'Color','w','InvertHardCopy','off');
                     topoplot(toplot(:,1),EEG.chanlocs,opt{:});
                     title('Topoplot','FontSize',12)
                 else
@@ -1455,8 +1465,8 @@ elseif LIMO.Level == 2
                     end
                 end
 
-                figure;
-                set(gcf,'Color','w')
+                hfig = figure;
+                set(hfig,'Color','w')
                 plot(xvect,squeeze(trimci(:,2)),'LineWidth',3);
                 fillhandle = patch([xvect,fliplr(xvect)], [trimci(:,1)' fliplr(trimci(:,3)')], [1 0 0]);
                 set(fillhandle,'EdgeColor',[1 0 1],'FaceAlpha',0.2,'EdgeAlpha',0.8);% set edge color
@@ -1777,7 +1787,8 @@ elseif LIMO.Level == 2
 
                 % make the figure(s)
                 % ------------------
-                figure;set(gcf,'Color','w')
+                hfig = figure;
+                set(hfig,'Color','w')
                 if regressor <= length(LIMO.design.nb_conditions) && ...
                         LIMO.design.nb_conditions ~= 0 % for categorical variables
                     brewcolours = limo_color_images(size(average,1));
@@ -1822,7 +1833,10 @@ elseif LIMO.Level == 2
 
                 else % 3D plots
                     for i=1:size(continuous,1)
-                        if i > 1; figure;set(gcf,'Color','w'); end
+                        if i > 1
+                            hfig = figure;
+                            set(hfig,'Color','w');
+                        end
                         index = find(~isnan(squeeze(continuous(i,1,:))));
                         if strcmpi(LIMO.Analysis,'Time') || strcmpi(LIMO.Analysis,'Time-Frequency')
                             if strcmpi(LIMO.Analysis,'Time')
@@ -1982,7 +1996,8 @@ elseif LIMO.Level == 2
                         end
                     end
 
-                    figure;set(gcf,'Color','w')
+                    hfig = figure;
+                    set(hfig,'Color','w')
                     for cond = 1:size(c,2)
                         plot(xvect,avg(:,cond)','LineWidth',3,'color',brewcolours(cond,:));
                         fillhandle = patch([xvect fliplr(xvect)], [c(:,cond)',fliplr(b(:,cond)')], brewcolours(cond,:));
@@ -2109,7 +2124,8 @@ elseif LIMO.Level == 2
                         end
                     end
 
-                    figure;set(gcf,'Color','w'); hold on
+                    hfig = figure;
+                    set(hfig,'Color','w'); hold on
                     brewcolours = limo_color_images(size(Effect,2));
                     if strcmpi(LIMO.Analysis,'Time')
                         xvect = LIMO.data.start:(1000/LIMO.data.sampling_rate):LIMO.data.end; % in sec
@@ -2213,7 +2229,8 @@ elseif LIMO.Level == 2
                         end
                     end
 
-                    figure; set(gcf,'Color','w'); hold on
+                    hfig = figure;
+                    set(hfig,'Color','w'); hold on
                     if strcmpi(LIMO.Analysis,'Time')
                         xvect = LIMO.data.start:(1000/LIMO.data.sampling_rate):LIMO.data.end; % in sec
                     else
@@ -2284,7 +2301,8 @@ elseif strcmpi(LIMO.Level,'LI')
                 scale(scale==0)=NaN;
             end
 
-            figure; set(gcf,'Color','w');
+            hfig = figure;
+            set(hfig,'Color','w');
             timevect = linspace(LIMO.data.start*1000,LIMO.data.end*1000,size(M,2));
             imagesc(timevect,1:size(M,1),scale);
             title(mytitle,'FontSize',18);
@@ -2401,7 +2419,7 @@ if strcmpi(Domain,'Time')
     % set(gca,'Colormap',limo_color_images(EEG.data),'CLim',[min(EEG.data(:)),max(EEG.data(:))])
 else % freq
     N = size(EEG.freq,2);
-    figure;
+    hfig = figure;
     for f=1:N
         if N<=6
             subplot(1,N,f)

--- a/limo_plot_difference.m
+++ b/limo_plot_difference.m
@@ -458,7 +458,8 @@ if strcmp(figure_flag,'on') || figure_flag == 1
     end
     
     % figure
-    figure;set(gcf,'Color','w'); 
+    hfig = figure;
+    set(hfig,'Color','w');
     subplot(3,2,[1 2 3 4]); 
     if ndims(Diff) == 4
         if strcmpi(restrict ,'time')

--- a/limo_plots.m
+++ b/limo_plots.m
@@ -100,7 +100,8 @@ while go == 1
             end
             
             plotted_data = limo_trimmed_mean(squeeze(data(:,:,p,:)),20/100);
-            figure('Name',['Plot of 20% trimmed mean ',num2str(p)]); set(gcf,'Color','w');
+            hfig = figure('Name',['Plot of 20% trimmed mean ',num2str(p)]);
+            set(hfig,'Color','w');
             surf(plotted_data); axis tight, grid on; shading interp
             ylabel('electrodes') ; xlabel('frames'); set(gca,'FontSize',14);
             assignin('base','Plotted_data',plotted_data)
@@ -129,8 +130,8 @@ while go == 1
             [r,pval] = corr(x,y,'type','Spearman'); % get r and p and mask of significant values after bootsrap
             [pID,pN] = limo_FDR(pval(pval<0.5),.05); % correct for multiple comparisons
             r(pval<pN)=NaN;
-            figure('Name',['Correlation of trimmed mean parameters ',num2str(p)]);
-            set(gcf,'Color','w'); subplot(1,2,1); imagesc(r); xlabel('time');ylabel('time')
+            hfig = figure('Name',['Correlation of trimmed mean parameters ',num2str(p)]);
+            set(hfig,'Color','w'); subplot(1,2,1); imagesc(r); xlabel('time');ylabel('time')
             axis square; title({['correlations across electrodes']; ['with FDR correction']},'Fontsize',15);
 
             % for each electrode across frames
@@ -187,7 +188,8 @@ while go == 1
             
             % make figure
             % ideally the axes would be labelled with time_info =time_vector(frames);
-            figure('Name',['Joint scatter of trimmed mean parameters ',num2str(p)]); set(gcf,'Color','w');
+            hfig = figure('Name',['Joint scatter of trimmed mean parameters ',num2str(p)]);
+            set(hfig,'Color','w');
             subplot(2,2,1); plotmatrix(x); xlabel('time'); ylabel('time'); title(sprintf('scatter plots per frame parameter %g',p(1)),'Fontsize',12);
             subplot(2,2,2); plotmatrix(x,y); title('joint scatter plots of parameters','Fontsize',12);
             subplot(2,2,4); plotmatrix(y); xlabel('time'); ylabel('time'); title(sprintf('scatter plots per frame parameter %g',p(2)),'Fontsize',12);
@@ -246,7 +248,8 @@ while go == 1
             % do the figures
             time_info = time_vector(frames);
             for i = 1:length(frames)
-                figure('Name','Parameter boxplot');set(gcf,'Color','w')
+                hfig = figure('Name','Parameter boxplot');
+                set(hfig,'Color','w')
                 % boxplot(squeeze(data(electrode,frames(i),p,:))','notch','on');
                 [est,HDI]=data_plot(squeeze(data(electrode,frames(i),p,:))','estimator','trimmed mean')
                 xlabel('Regressor(s)','FontSize',16)

--- a/limo_random_robust.m
+++ b/limo_random_robust.m
@@ -687,7 +687,7 @@ switch type
         if strcmpi(go,'no')
             go = limo_questdlg('Are your ready to start the analysis?','Start GLM analysis','No','Yes','Yes');
         end
-        close('LIMO design');        
+        close(findobj('Name','LIMO design'));
 
         if strcmpi(go,'Yes')
             save(fullfile(LIMO.dir,'LIMO.mat'),'LIMO');
@@ -774,7 +774,7 @@ switch type
                 go = questdlg('run the analysis?','Start GLM analysis','Yes','No','Yes');
             end
         end
-        close('LIMO design');
+        close(findobj('Name','LIMO design'));
         
         if strcmpi(go,'Yes')
             if LIMO.design.fullfactorial == 0 && LIMO.design.nb_continuous == 0
@@ -1054,12 +1054,13 @@ switch type
             % check the design with user
             % --------------------------
             if ~strcmpi(go,'Yes')
-                figure('Name','LIMO design'); set(gcf,'Color','w');
+                hfig = figure('Name','LIMO design');
+                set(hfig,'Color','w');
                 imagesc(LIMO.design.X); colormap('gray');
                 title('ANOVA model','FontSize',16);xlabel('regressors');
                 ylabel('subjects'); drawnow;
                 go = limo_questdlg('Are your ready to start the analysis?','Start GLM analysis','No','Yes','Yes');
-                close('LIMO design')
+                close(hfig)
                 if ~strcmpi(go,'Yes')
                     return
                 end

--- a/limo_rep_anova_old.m
+++ b/limo_rep_anova_old.m
@@ -171,7 +171,8 @@ switch type
             x0 = repmat(eye(nb_subjects),nb_conditions,1); % error
             X = [x x0];
             if flag == 1
-                figure('Name','Design matrix'); set(gcf,'Color','w'); imagesc(X);
+                hfig = figure('Name','Design matrix');
+                set(hfig,'Color','w'); imagesc(X);
                 colormap('gray');  title('ANOVA model','FontSize',16);xlabel('regressors'); 
                 ylabel('scaled model values'); drawnow; 
                 go = questdlg('start the analysis?');
@@ -299,7 +300,8 @@ switch type
         end
         
         if flag == 1
-            figure('Name','Design matrix'); set(gcf,'Color','w'); imagesc([X Subjects]);
+            hfig = figure('Name','Design matrix');
+            set(hfig,'Color','w'); imagesc([X Subjects]);
             colormap('gray');  title('ANOVA model','FontSize',16);xlabel('regressors');
             ylabel('scaled model values'); drawnow;
             go = questdlg('start the analysis?');
@@ -421,7 +423,8 @@ switch type
         
         X = [Gp x XGp S];
         if flag == 1
-            figure('Name','Design matrix'); set(gcf,'Color','w'); imagesc(X);
+            hfig = figure('Name','Design matrix');
+            set(hfig,'Color','w'); imagesc(X);
             colormap('gray');  title('ANOVA model','FontSize',16);xlabel('regressors');
             ylabel('scaled model values'); drawnow;
             go = questdlg('start the analysis?');
@@ -615,7 +618,8 @@ switch type
         end
         
         if flag == 1
-            figure('Name','Design matrix'); set(gcf,'Color','w'); imagesc([X Subjects]);
+            hfig = figure('Name','Design matrix');
+            set(hfig,'Color','w'); imagesc([X Subjects]);
             colormap('gray');  title('ANOVA model','FontSize',16);xlabel('regressors');
             ylabel('scaled model values'); drawnow;
             go = questdlg('start the analysis?');

--- a/limo_review.m
+++ b/limo_review.m
@@ -29,8 +29,8 @@ else
 end
 
 %% Display
-figure('Name','Review Design')
-set(gcf,'Color','w');
+hfig = figure('Name','Review Design');
+set(hfig,'Color','w');
 
 if size(LIMO.design.X,2) == 1
     imagesc(LIMO.design.X/2); colormap(gca, gray);


### PR DESCRIPTION
## Summary
- use figure handles instead of `gcf` when setting figure properties
- close figures using handles
- update several plotting utilities

## Testing
- `octave` not installed, no tests run

------
https://chatgpt.com/codex/tasks/task_e_685d430a53e48325b59a46974fa7156e