### PR TITLE
Fix limo_mglm: capture eigenvalues (not eigenvectors) from limo_decomp

### DIFF
--- a/limo_mglm.m
+++ b/limo_mglm.m
@@ -179,7 +179,7 @@ if nb_factors == 1   %  1-way MANOVA
     Sxx = S(size(Y,2)+1:size(S,1),size(Y,2)+1:size(S,2));
     Rsquare_multi = trace(Sxy*Syx) / sqrt(trace(Sxx.^2)*trace(Syy.^2)); % Robert and Escoufier, J.Royal Stat Soc, C - 1976
 
-    Eigen_values_R2 = limo_decomp(E,H);
+    [~,Eigen_values_R2] = limo_decomp(E,H);
     p = size(Y,2); % = number of variables (dimension)
     q = rank(X); % = number of regressors (df)
     s = min(p,q); % df
@@ -312,7 +312,7 @@ elseif nb_factors > 1  && isempty(nb_interactions) % N-ways MANOVA without inter
     R0   = eye(size(Y,1)) - (X0*pinv(X0));
     M    = R0 - R;      % M is the projection matrix onto Xc
     H    = (Betas'*X'*M*X*Betas);   % SSCP Hypothesis (Effect)
-    Eigen_values_R2 = limo_decomp(E,H);
+    [~,Eigen_values_R2] = limo_decomp(E,H);
 
     % Generalized R2
     % variance covariance matrix
@@ -358,7 +358,7 @@ elseif nb_factors > 1  && isempty(nb_interactions) % N-ways MANOVA without inter
         R0   = eye(size(Y,1)) - (X0*pinv(X0));
         M    = R0 - R;
         H    = (Betas'*X'*M*X*Betas);
-        Eigen_values_cond = limo_decomp(E,H);
+        [~,Eigen_values_cond] = limo_decomp(E,H);
         model.conditions.EV(f,:) = Eigen_values_cond';
 
         vh = nb_conditions(f) - 1; % df = q above
@@ -451,7 +451,7 @@ elseif nb_factors > 1  && ~isempty(nb_interactions) % N-ways MANOVA with interac
     R0   = eye(size(Y,1)) - (X0*pinv(X0));
     M    = R0 - R;      % M is the projection matrix onto Xc
     H    = (Betas'*X'*M*X*Betas);   % SSCP Hypothesis (Effect)
-    Eigen_values_cond = limo_decomp(E,H);
+    [~,Eigen_values_cond] = limo_decomp(E,H);
 
     % Generalized R2
     % variance covariance matrix
@@ -462,7 +462,7 @@ elseif nb_factors > 1  && ~isempty(nb_interactions) % N-ways MANOVA with interac
     Sxx = S(size(Y,2)+1:size(S,1),size(Y,2)+1:size(S,2));
     Rsquare_multi = trace(Sxy*Syx) / sqrt(trace(Sxx.^2)*trace(Syy.^2)); % Robert and Escoufier, J.Royal Stat Soc, C - 1976
 
-    Eigen_values_R2 = limo_decomp(E,H);
+    [~,Eigen_values_R2] = limo_decomp(E,H);
     p = size(Y,2); % = number of variables (dimension)
     q = rank(X); % = number of regressors (df)
     s = min(p,q); % df
@@ -517,7 +517,7 @@ elseif nb_factors > 1  && ~isempty(nb_interactions) % N-ways MANOVA with interac
         R0   = eye(size(Y,1)) - (X0*pinv(X0));
         M    = R0 - R;
         H(f,:) = diag((betas'*x'*M*x*betas));
-        Eigen_values_cond = limo_decomp(E,H);
+        [~,Eigen_values_cond] = limo_decomp(E,H);
         model.conditions.EV(f,:) = Eigen_values_cond';
 
         vh = nb_conditions(f) - 1; % df = q above
@@ -584,7 +584,7 @@ elseif nb_factors > 1  && ~isempty(nb_interactions) % N-ways MANOVA with interac
 
     if nb_factors == 2 && nb_continuous == 0 % the quick way with only one interaction
         HI = diag(T)' - H(1,:) - H(2,:) - diag(E)';
-        Eigen_values_inter = limo_decomp(E,HI);
+        [~,Eigen_values_inter] = limo_decomp(E,HI);
         model.interactions.EV = [Eigen_values_inter'];
 
         vh = nb_interactions - 1; % df = q above
@@ -701,7 +701,7 @@ elseif nb_factors > 1  && ~isempty(nb_interactions) % N-ways MANOVA with interac
             R0   = eye(size(Y,1)) - (X0*pinv(X0));
             M    = R0 - R;
             HI(f,:) = diag((betas'*x'*M*x*betas))';
-            Eigen_values_inter = limo_decomp(E,HI(f,:));
+            [~,Eigen_values_inter] = limo_decomp(E,HI(f,:));
             model.interactions.EV(f,:) = Eigen_values_inter';
 
             vh = nb_interactions(f) - 1; % df = q above
@@ -789,7 +789,7 @@ if nb_continuous ~=0
         R0 = eye(size(Y,1)) - (X0*pinv(X0));
         M  = R0 - R;
         H  = (Betas'*X'*M*X*Betas);
-        Eigen_values_R2 = limo_decomp(E,H);
+        [~,Eigen_values_R2] = limo_decomp(E,H);
 
         % Generalized R2
         % variance covariance matrix
@@ -800,7 +800,7 @@ if nb_continuous ~=0
         Sxx = S(size(Y,2)+1:size(S,1),size(Y,2)+1:size(S,2));
         Rsquare_multi = trace(Sxy*Syx) / sqrt(trace(Sxx.^2)*trace(Syy.^2)); % Robert and Escoufier, J.Royal Stat Soc, C - 1976
 
-        Eigen_values_R2 = limo_decomp(E,H);
+        [~,Eigen_values_R2] = limo_decomp(E,H);
         p = size(Y,2); % = number of variables (dimension)
         q = rank(X); % = number of regressors (df)
         s = min(p,q); % df
@@ -832,7 +832,7 @@ if nb_continuous ~=0
             R0   = eye(size(Y,1)) - (X0*pinv(X0));
             M    = R0 - R;
             H    = Betas'*X'*M*X*Betas;
-            Eigen_values_continuous = limo_decomp(E,H);
+            [~,Eigen_values_continuous] = limo_decomp(E,H);
             model.continuous.EV = [model.continuous.EV Eigen_values_continuous'];
 
             df_continuous = size(Y,2);


### PR DESCRIPTION
## Problem
`limo_decomp` is declared `function [eigen_vectors, eigen_values] = limo_decomp(E,H)` — the **first** output is the *p×p eigenvector matrix*, the second is the eigenvalue vector.

In `limo_mglm.m`, eleven **single-output** calls capture the first output into a variable named `Eigen_values_*` and feed it straight into the Roy and Pillai *F* formulas:

```matlab
Eigen_values_R2 = limo_decomp(E,H);          % captures the eigenVECTOR matrix
theta = max(Eigen_values_R2) / (1+max(Eigen_values_R2));   % Roy — becomes a 1×p row vector
V     = sum(Eigen_values_R2 ./ (1+Eigen_values_R2));       % Pillai — sums a whole matrix
```

Line 214 already uses the correct two-output form `[Eigen_vectors_cond,Eigen_values_cond] = limo_decomp(E,H)`, confirming the intended order.

## Fix
Request the second output at all 11 call sites (lines 182, 315, 361, 454, 465, 520, 587, 704, 792, 803, 835):
```matlab
[~,Eigen_values_R2] = limo_decomp(E,H);
```

## Impact
Every multivariate (MANOVA / MANCOVA) statistic from `limo_mglm` — Roy's and Pillai's R², condition and continuous effects — was computed from eigenvector entries instead of the eigenvalues of `inv(E)·H`, so results were wrong in both **value and shape**. The default mass-univariate path (`limo_glm`) is unaffected.

## Reproduction
```matlab
%% Reproduction — Critical #1: limo_mglm captures eigenVECTORS, not eigenvalues
% limo_decomp is declared  [eigen_vectors, eigen_values] = limo_decomp(E,H)  --
% the FIRST output is the p x p eigenvector matrix, the SECOND is the eigenvalue
% vector. Eleven single-output calls in limo_mglm.m (e.g. line 182) captured the
% first output into a variable named Eigen_values_* and fed it into the Roy /
% Pillai F formulas, so every multivariate statistic was computed from the
% eigenvectors instead of the eigenvalues of inv(E)*H.
%
% This shows (i) the single-output form returns the eigenvector matrix, and
% (ii) Roy's statistic is a well-formed SCALAR when built from the eigenvalues
% (the fix) but a meaningless 1 x p ROW VECTOR when built from what the buggy
% code captured. Run from the limo_tools root.

rng(42);
p = 5;
E = cov(randn(30,p));   % error SSCP-like (p x p, pos-def)
H = cov(randn(30,p));   % hypothesis SSCP-like (p x p)

[eigen_vectors, eigen_values] = limo_decomp(E,H);   % correct 2-output form (the fix)
captured = limo_decomp(E,H);                         % what limo_mglm captured (1-output)

fprintf('single-output size = [%d %d] (eigenVECTOR matrix); true eigenvalues = [%d %d]\n', ...
        size(captured), size(eigen_values));
assert(isequal(captured, eigen_vectors), 'the single-output form returns the eigenvector matrix');

% Roy largest-root statistic: theta = max(ev)/(1+max(ev)); F uses max(ev)
theta_fixed = max(eigen_values) / (1+max(eigen_values));   % from eigenvalues  -> scalar
theta_buggy = max(captured)    ./ (1+max(captured));        % from eigenvectors -> 1 x p vector

fprintf('Roy theta  fixed (eigenvalues) = %.6f   (scalar)\n', theta_fixed);
fprintf('Roy theta  buggy (eigenvectors)= [%s] (1 x %d row vector)\n', ...
        strtrim(sprintf('%.4f ', theta_buggy)), numel(theta_buggy));

assert(isscalar(theta_fixed), 'fixed Roy statistic is a scalar');
assert(~isscalar(theta_buggy) && numel(theta_buggy)==p, 'buggy Roy statistic is a p-vector');
assert(abs(theta_fixed - theta_buggy(1)) > 1e-6, 'fixed and buggy differ');
disp('PASS: the fix makes Roy/Pillai use the eigenvalues (scalar) instead of eigenvectors.');
```

## Verification
Run under **MATLAB R2025a** from the repo root with the fix applied:
```
single-output size = [5 5] (eigenVECTOR matrix); true eigenvalues = [5 1]
Roy theta  fixed (eigenvalues) = 0.671943   (scalar)
Roy theta  buggy (eigenvectors)= [0.4008 0.3490 0.3789 0.0620 0.2431] (1 x 5 row vector)
PASS: the fix makes Roy/Pillai use the eigenvalues (scalar) instead of eigenvectors.
```

_Part of a broader Opus 4.8 multi-agent review of v4.2.1 — full report: https://devon7y.github.io/limo-opus-bug-review/_