### PR TITLE
Fix limo_robust_rep_anova argument contract and within-subject path

### DIFF
--- a/limo_robust_rep_anova.m
+++ b/limo_robust_rep_anova.m
@@ -1,145 +1,192 @@
 function result = limo_robust_rep_anova(varargin)
 
-% result = limo_rep_anova(data,gp,factors)
+% result = limo_robust_rep_anova(data,gp,factors)
 %
-% This function computes a robust repeated measures ANOVAs. 
-% Unlike standard ANOVAs, we use a multivariate framework which accounts 
-% for the correlation across measures. One advantage of this approach is 
+% This function computes a robust repeated measures ANOVA.
+% Unlike standard ANOVAs, we use a multivariate framework which accounts
+% for the correlation across measures. One advantage of this approach is
 % that one does not have to account for sphericity.
 % We simply compute the T2 Hotelling test on the repeated measures.
 % On top of that, means are substituted by trimmed means and variance by
 % winsorized variances -- this allows to have a robust version of the test.
 % The code implements equations described in:
 % Rencher (2002) Methods of multivariate analysis John Wiley.
-% with modifications for trimmed means and winsorized covariance
+% with modifications for trimmed means and winsorized covariance.
+%
+% This is the robust analogue of limo_rep_anova and MUST share its calling
+% convention: it is called from limo_random_robust and limo_contrast with
+% the group vector gp as the 2nd argument (see those callers).
 %
 % INPUT
 %
-%   result = limo_rep_anova(data,factors)
-%   result = limo_rep_anova(data,factors,C)
-%   result = limo_rep_anova(data,factors,C,S)
+%   result = limo_robust_rep_anova(data,gp,factors)
+%   result = limo_robust_rep_anova(data,gp,factors,C)
+%   result = limo_robust_rep_anova(data,gp,factors,C,S)   % S = robust cov (within only)
 %
-% - data is a 3D matrix (f time frames * n subjects * p measures) of repeated measures
+% - data is a 3D matrix (f time/freq frames * n subjects * p measures)
+% - gp is a vector (n*1) indicating to which group subjects belong.
+%       Enter [] (or a constant vector) if all subjects belong to the same group.
 % - factors is a vector indicating the levels of each factor
 %       (prod(factors)=p), e.g. [2 2] for a 2 by 2 factorial
-% - C is optional and represent the contrast vector to compute (see limo_OrthogContrasts)
-% - S is optional and is the covariance of the data 
+% - C is optional and represents the contrast(s) to compute (see limo_OrthogContrasts)
+% - S is optional and is the (robust) covariance of the data (within factors only)
 %
 % OUTPUT
 %
-%   F     = F value of the Hotelling T2 test
-%   p     = corresponding level of significance
-%   names = a letter per factor by default
+%   - One sample repeated measure (within only, 1 factor)
+%       result.F  result.df  result.dfe  result.p
 %
-%   - One sample repeated measure
-%       result.F
-%       result.p
-% 
-%   - Repeated measure with more than one factor
-%       result.F
-%       result.p
-%       result.names
-% 
-% See also limo_rfep_anova, limo_random_robust, limo_OrthogContrasts
+%   - Repeated measure with more than one factor (within only)
+%       result.F  result.df  result.dfe  result.p  result.names
+%
+% NOTE on between-group designs: a *robust* within-by-between repeated
+% measures ANOVA (i.e. gp defines more than one group) is not implemented.
+% The pooled between-group covariance required for a trimmed-mean Hotelling
+% test is not a drop-in substitution of limo_robust_cov and needs a
+% dedicated, validated derivation. Such designs error out here rather than
+% return an unvalidated statistic; use limo_rep_anova (non-robust) instead.
+%
+% See also limo_rep_anova, limo_random_robust, limo_OrthogContrasts,
+%          limo_trimmed_mean, limo_robust_cov
 %
 % Cyril Pernet & Guillaume Rousselet April 2014
 % ------------------------------
 %  Copyright (C) LIMO Team 2019
 
+percent = 20; % percentage of trimming for trimmed means / winsorized cov
 
 %% input stuff
 % -------------
-C = []; S = []; 
-          
-if nargin == 2
-    Data = varargin{1};
-    factors = varargin{2};
-elseif nargin == 3 || nargin == 4
-    Data = varargin{1};
-    factors = varargin{2};
-    C = varargin{3};
-    if nargin == 4
-        S = varargin{4}; % sample cov
+C = []; S = [];
+
+if nargin == 3
+    Data    = varargin{1};
+    gp      = varargin{2};
+    factors = varargin{3};
+elseif nargin == 4 || nargin == 5
+    Data    = varargin{1};
+    gp      = varargin{2};
+    factors = varargin{3};
+    C       = varargin{4};
+    if nargin == 5
+        % as in limo_rep_anova: a 5th argument whose number of rows matches
+        % gp is the between-group design matrix X; otherwise it is the
+        % within covariance S.
+        if size(varargin{2},1) == size(varargin{5},1)
+            X = varargin{5}; %#ok<NASGU> % design matrix for groups (between)
+        else
+            S = varargin{5}; % sample covariance if no groups
+        end
     end
 else
     error('wrong number of arguments')
+end
+
+if isempty(gp)
+    gp = ones(size(Data,2), 1);
 end
 
 clear varargin
 
 %% basic info about the design
 % -----------------------------
-[f,n,p]       = size(Data);
-nb_factors    = size(factors,2);
-nb_effects    = (2^nb_factors - 1);
-nb_conditions = prod(factors);
+[f,n,p]    = size(Data); %#ok<ASGLU> % frames * subjects * measures
+nb_factors = size(factors,2);
 
-%% analyze
-% ---------
-type = nb_factors;
+% dispatch on within (single group) vs between (>1 group)
+if length(unique(gp)) == 1
+    if nb_factors == 1
+        type = 1;
+    else
+        type = 2;
+    end
+else
+    if nb_factors == 1
+        type = 3;
+    else
+        type = 4;
+    end
+end
 
-%% 
+%%
 switch type
-    
-% One sample repeated measure
-% ---------------------------
- 
+
+% One sample repeated measure (within factors only)
+% -------------------------------------------------
+
     % ---------------------------------------------------------------------
-    case{1}  % 1 factor
+    case 1  % 1 factor
         % -----------------------------------------------------------------
-        if isempty(C) 
+        if isempty(C)
             C = [eye(p-1) ones(p-1,1).*-1];  % contrast matrix
         end
-        
+
         if isempty(S)
             S = NaN(size(Data,1),size(Data,3),size(Data,3));
-            for time = 1:size(Data,1)
-                S(time,:,:) = limo_robust_cov(squeeze(Data(time,:,:))); % covariance to account for spericity
+            for frame = 1:size(Data,1)
+                S(frame,:,:) = limo_robust_cov(squeeze(Data(frame,:,:))); % winsorized covariance
             end
         end
 
-        df           = p-1; 
-        dfe          = n-p+1; 
-        y            = squeeze(limo_trimmed_mean(Data,2)); % these are the means to compare
-        for time = 1:size(Data,1)
-            Tsquare(time)      = n*(C*y(time,:)')'*inv(C*squeeze(S(time,:,:))*C')*(C*y(time,:)');   % Hotelling Tsquare
+        df  = p-1;
+        dfe = n-p+1;
+        % trimmed mean ACROSS SUBJECTS (dim 2) -> f x p ; limo_trimmed_mean
+        % reduces the 3rd dim, so bring subjects to the 3rd dim first.
+        y   = limo_trimmed_mean(permute(Data,[1 3 2]),percent); % f x p (means to compare)
+        for frame = 1:size(Data,1)
+            Tsquare(frame) = n*(C*y(frame,:)')'*inv(C*squeeze(S(frame,:,:))*C')*(C*y(frame,:)'); %#ok<*MINV> % Hotelling Tsquare
         end
-        result.F     = ( dfe / ((n-1)*df) ) * Tsquare; 
-        result.p     = 1 - fcdf(result.F, df, dfe);
+        result.F   = ( dfe / ((n-1)*df) ) * Tsquare;
+        result.df  = df;
+        result.dfe = dfe;
+        result.p   = 1 - fcdf(result.F, df, dfe);
 
         % -----------------------------------------------------------------
-    case{2} % several factors
+    case 2 % several factors
         % -----------------------------------------------------------------
-        if isempty(C) 
-            [C,result.names] = limo_OrthogContrasts(factors); % set of orthogonal contrasts between factors
+        if isempty(C)
+            [C,result.names] = limo_OrthogContrasts(factors); % orthogonal contrasts between factors
         end
-        
+
         if isempty(S)
             S = NaN(size(Data,1),size(Data,3),size(Data,3));
-            for time = 1:size(Data,1)
-                S(time,:,:) = limo_robust_cov(squeeze(Data(time,:,:))); % covariance to account for spericity
+            for frame = 1:size(Data,1)
+                S(frame,:,:) = limo_robust_cov(squeeze(Data(frame,:,:))); % winsorized covariance
             end
         end
-        
-        y = squeeze(limo_trimmed_mean(Data,20)); % these are the means to compare   
+
+        y = limo_trimmed_mean(permute(Data,[1 3 2]),percent); % f x p (means to compare)
         if iscell(C)
             for effect = 1:size(C,2)
                 c                    = C{effect};
-                df(effect)           = rank(c);
-                dfe(effect)          = n-df(effect);
-                for time = 1:size(Data,1)
-                    Tsquare(time)    =  n*(c*y(time,:)')'*inv(c*squeeze(S(time,:,:))*c')*(c*y(time,:)'); % is also t = sqrt(n*(c*y)'*inv(c*S*c')*(c*y));
+                df                   = rank(c);
+                dfe                  = n-df;
+                for frame = 1:size(Data,1)
+                    Tsquare(frame)   =  n*(c*y(frame,:)')'*pinv(c*squeeze(S(frame,:,:))*c')*(c*y(frame,:)');
                 end
-                result.F(effect,:)   = ( dfe(effect) / ((n-1)*(df(effect))) ) * Tsquare;
-                result.p(effect,:)   =  1 - fcdf(result.F(effect,:), df(effect), dfe(effect));
+                result.F(effect,:)   = ( dfe / ((n-1)*(df)) ) * Tsquare;
+                result.p(effect,:)   =  1 - fcdf(result.F(effect,:), df, dfe);
+                result.df(effect)    = df;
+                result.dfe(effect)   = dfe;
             end
         else
-            df           = rank(C);
-            dfe          = n-df;
-            for time = 1:size(Data,1)
-                Tsquare(time)    =  n*(C*y(time,:)')'*inv(C*squeeze(S(time,:,:))*C')*(C*y(time,:)');
+            df  = rank(C);
+            dfe = n-df;
+            for frame = 1:size(Data,1)
+                Tsquare(frame) =  n*(C*y(frame,:)')'*pinv(C*squeeze(S(frame,:,:))*C')*(C*y(frame,:)');
             end
             result.F   = ( dfe / ((n-1)*(df)) ) * Tsquare;
             result.p   =  1 - fcdf(result.F, df, dfe);
+            result.df  = df;
+            result.dfe = dfe;
         end
- end
+
+% k samples repeated measure (within-by-between)
+% ----------------------------------------------
+    case {3,4}
+        error(['limo_robust_rep_anova:betweenNotSupported : robust repeated ' ...
+            'measures ANOVA with a between-group factor is not implemented. ' ...
+            'A validated trimmed-mean pooled-covariance derivation is required; ' ...
+            'use limo_rep_anova (non-robust) for within-by-between designs.'])
+end
+end


### PR DESCRIPTION
## Problem
Every caller (`limo_random_robust`, `limo_contrast`) invokes the function as `limo_robust_rep_anova(Y, gp, factor_levels, C [, XB])` — the group vector `gp` is the **2nd** argument, exactly like the non-robust sibling `limo_rep_anova(data, gp, factors, C, S/X)`. But the parser read the arguments as `(Data, factors, C, S)`:

- the 5-argument (between-group) calls hit `error('wrong number of arguments')`;
- the 4-argument (within) calls bound `factors = gp`, `C = factor_levels`, `S = contrast`, then crashed at `C*y` (dimension mismatch).

It also never set `result.df` / `result.dfe` (which the caller reads), computed the trimmed mean across the wrong dimension (measures instead of subjects), and mis-squeezed single-frame data.

## Fix
- Re-parse arguments to `(Data, gp, factors, C, S/X)`, matching all callers and `limo_rep_anova`.
- Dispatch **within** vs **between** on `gp`.
- Within-subject cases: trimmed mean now reduces the **subjects** dimension; `result.df` / `result.dfe` are set; the single-frame squeeze is avoided.
- **Between-group** designs (`gp` defines >1 group) now raise a clear, explicit error instead of a cryptic crash. A correct *robust* within-by-between test needs a validated trimmed-mean pooled-covariance derivation (`limo_robust_cov` is scaled per single group and is **not** a drop-in for the pooled between-group SSCP); this is left as a follow-up rather than shipping an unvalidated statistic. Use `limo_rep_anova` (non-robust) for such designs meanwhile.

## Impact
The robust ("Trimmed Mean") repeated-measures path previously errored for every design, so no prior numbers change — this makes the within-subject case functional and fails the between-group case loudly.

## Reproduction
```matlab
%% Reproduction — Critical #2: limo_robust_rep_anova argument-contract mismatch
% Every caller (limo_random_robust, limo_contrast) invokes:
%     limo_robust_rep_anova(Y, gp, factor_levels, C [, XB])
% i.e. the group vector gp is the 2nd argument, exactly like the sibling
% limo_rep_anova(data, gp, factors, C, S/X). Before the fix the parser read
% the args as (Data, factors, C, S): the 5-arg (between-group) form hit
% error('wrong number of arguments'), and the 4-arg form bound factors=gp,
% C=factor_levels, S=contrast, then crashed at C*y (dimension mismatch).
% It also never set result.df / result.dfe (which the caller reads), computed
% the trimmed mean across the wrong dimension (measures, not subjects), and
% mis-squeezed single-frame data.
%
% This script exercises the FIXED within-subject path and checks it returns a
% valid Hotelling-T2 result with df/dfe, matching the structure of the
% non-robust limo_rep_anova. Run from the limo_tools root.

rng(7);
f = 12;    % time/freq frames
n = 25;    % subjects
levels = 4;                 % one within factor, 4 levels (p = prod(levels))
gp = ones(n,1);             % single group (within-subject design)
C  = [eye(levels-1) -ones(levels-1,1)];   % within contrast

% data: f x n x p, a real within-subject effect on measure 1
Data = randn(f,n,levels);
Data(:,:,1) = Data(:,:,1) + 1.2;

result = limo_robust_rep_anova(Data, gp, levels, C);   % <-- FIXED call

assert(isfield(result,'F')  && numel(result.F)==f,  'result.F is 1 x frames');
assert(isfield(result,'p')  && numel(result.p)==f,  'result.p is 1 x frames');
assert(isfield(result,'df') && isscalar(result.df), 'result.df is set (caller needs it)');
assert(isfield(result,'dfe')&& isscalar(result.dfe),'result.dfe is set (caller needs it)');
assert(all(result.F>=0) && all(result.p>=0 & result.p<=1), 'F>=0 and p in [0,1]');

fprintf('within-subject robust rep-ANOVA OK: df=%d dfe=%d  meanF=%.3f  min p=%.4g\n', ...
        result.df, result.dfe, mean(result.F), min(result.p));

% single-frame case must not crash (previously mis-squeezed -> #49)
r1 = limo_robust_rep_anova(Data(1,:,:), gp, levels, C);
assert(isscalar(r1.F), 'single-frame returns a scalar F');
disp('PASS: within path returns valid df/dfe/F/p, incl. single-frame.');

% between-group form now fails LOUDLY instead of a cryptic crash / wrong stat:
try
    XB = [gp==1, ones(n,1)];
    limo_robust_rep_anova(Data, [ones(12,1);2*ones(13,1)], levels, C, XB);
    error('expected a clear not-implemented error for between-group');
catch ME
    fprintf('between-group correctly errors: %s\n', ME.message);
end
```

## Verification
Run under **MATLAB R2025a** from the repo root with the fix applied:
```
within-subject robust rep-ANOVA OK: df=3 dfe=22  meanF=232.085  min p=0
PASS: within path returns valid df/dfe/F/p, incl. single-frame.
between-group correctly errors: limo_robust_rep_anova:betweenNotSupported : robust repeated
measures ANOVA with a between-group factor is not implemented. ... use limo_rep_anova
(non-robust) for within-by-between designs.
```

_Part of a broader Opus 4.8 multi-agent review of v4.2.1 — full report: https://devon7y.github.io/limo-opus-bug-review/_