### PR TITLE
Fix limo_random_select: assemble subjects in file order (getdata)

### DIFF
--- a/limo_random_select.m
+++ b/limo_random_select.m
@@ -1953,7 +1953,7 @@ if stattest == 1 % one sample
         LIMO.data.data = LIMO.data.data';
     end
 
-    for i=size(LIMO.data.data,1):-1:1 % for each subject
+    for i=1:size(LIMO.data.data,1) % for each subject
         tmp = load(LIMO.data.data{i});
 
         % get indices to trim data


### PR DESCRIPTION
## Problem
In `getdata` (single-list branch, ~line 1956) the subject loop ran **backward** while the compacting write pointer `index` (initialised to 1, `index = index + 1` per kept subject) ran **forward**:
```matlab
index = 1;
for i = size(LIMO.data.data,1):-1:1   % backward
    ...
    data(:,:,:,index) = ...            % forward-filled
    index = index + 1;
end
```
So the assembled data cube's subject axis comes out **reversed** relative to file order — and relative to the regressor design matrix `X`, which is built in file order. The `removed(i)` bookkeeping is indexed by true subject `i`, further misaligning it with the compacted columns.

## Fix
Iterate forward: `for i = 1:size(LIMO.data.data,1)`. The compacting `index` still correctly skips discarded subjects.

## Impact
- **Second-level regression**: each subject's data was paired with the **wrong** regressor row → wrong betas / t / p (silent).
- One-sample / group-mean tests are order-invariant, so those are unaffected numerically.

## Reproduction
```matlab
%% Reproduction — Critical #3: reversed subject loop in limo_random_select getdata
% In getdata (single-list branch, ~line 1956) the loop ran BACKWARD while the
% write pointer `index` (initialised to 1, incremented +1 per kept subject) ran
% FORWARD. The assembled data cube's subject axis therefore came out reversed
% relative to file order -- and relative to the regressor design matrix X, which
% is built in file order. For a 2nd-level regression this silently pairs each
% subject's data with the WRONG regressor row.
%
% This script isolates the exact index mechanism (no LIMO data needed) and shows
% the reversal, then the regression consequence. It reproduces the pre-fix loop
% and the fixed loop side by side.

nsub  = 6;
files = compose('subject_%d', 1:nsub);   % file order = subject order

% ---- pre-fix: backward loop, forward compacting index ----
index = 1; order_bug = zeros(1,nsub);
for i = nsub:-1:1                 % <-- buggy direction
    order_bug(index) = i;         % data(...,index) holds file i
    index = index + 1;
end

% ---- fixed: forward loop ----
index = 1; order_fix = zeros(1,nsub);
for i = 1:nsub                    % <-- fixed direction
    order_fix(index) = i;
    index = index + 1;
end

fprintf('data column ->  subject index\n');
fprintf('  pre-fix : [%s]  (reversed!)\n', strtrim(sprintf('%d ',order_bug)));
fprintf('  fixed   : [%s]  (matches file/regressor order)\n', strtrim(sprintf('%d ',order_fix)));

% ---- regression consequence ----
% true model: y_subject = beta * x_subject + noise, x in file order
rng(1); x = (1:nsub)';                 % regressor, file order (design matrix rows)
beta_true = 2.0;
y_fileorder = beta_true*x + 0.01*randn(nsub,1);

% GLM pairs data column k with regressor row k:
y_bug = y_fileorder(order_bug)';       % data assembled reversed
y_fix = y_fileorder(order_fix)';       % data assembled correctly
Xd = [x ones(nsub,1)];
b_bug = Xd \ y_bug(:);
b_fix = Xd \ y_fix(:);
fprintf('\nrecovered slope  true=%.3f  fixed=%.3f  buggy=%.3f\n', beta_true, b_fix(1), b_bug(1));
assert(abs(b_fix(1)-beta_true) < 0.05, 'fixed recovers the true slope');
assert(abs(b_bug(1)-beta_true) > 0.5,  'buggy slope is wrong (Y<->X scrambled)');
disp('PASS: forward loop restores Y<->X alignment; backward loop corrupts regression.');
```

## Verification
Run under **MATLAB R2025a** from the repo root with the fix applied:
```
data column ->  subject index
  pre-fix : [6 5 4 3 2 1]  (reversed!)
  fixed   : [1 2 3 4 5 6]  (matches file/regressor order)
recovered slope  true=2.000  fixed=1.998  buggy=-1.998
PASS: forward loop restores Y<->X alignment; backward loop corrupts regression.
```

_Part of a broader Opus 4.8 multi-agent review of v4.2.1 — full report: https://devon7y.github.io/limo-opus-bug-review/_