### PR TITLE
Fix limo_tfce_handling: correct TF null TFCE dimensionality (F-values)

### DIFF
--- a/limo_tfce_handling.m
+++ b/limo_tfce_handling.m
@@ -286,7 +286,7 @@ else % anything else last dimension is F and p
                 neighbouring_matrix = LIMO.data.neighbouring_matrix;
                 tfce_H0_score = NaN(1,size(H0_Fval,2),size(H0_Fval,3),nboot);
                 parfor b=1:nboot
-                    [tfce_H0_score(1,:,:,b),tfce_H0_thmaps{b}] = limo_tfce(1,squeeze(H0_Fval(:,:,:,1,b)),neighbouring_matrix,0);
+                    [tfce_H0_score(1,:,:,b),tfce_H0_thmaps{b}] = limo_tfce(2,squeeze(H0_Fval(:,:,:,1,b)),neighbouring_matrix,0);
                 end
             else
                 neighbouring_matrix = LIMO.data.neighbouring_matrix;
@@ -300,7 +300,7 @@ else % anything else last dimension is F and p
                 neighbouring_matrix = LIMO.data.neighbouring_matrix;
                 tfce_H0_score = NaN(size(H0_Fval,1),size(H0_Fval,2),size(H0_Fval,3),nboot);
                 parfor b=1:nboot
-                    [tfce_H0_score(:,:,:,b),tfce_H0_thmaps{b}] = limo_tfce(2,squeeze(H0_Fval(:,:,:,1,b)),neighbouring_matrix,0);
+                    [tfce_H0_score(:,:,:,b),tfce_H0_thmaps{b}] = limo_tfce(3,squeeze(H0_Fval(:,:,:,1,b)),neighbouring_matrix,0);
                 end
             else
                 neighbouring_matrix = LIMO.data.neighbouring_matrix;


### PR DESCRIPTION
## Problem
`limo_tfce` dispatches on dimensionality: `type 2` reads `[x,y,b]=size(data)` (3rd dim = bootstraps), `type 3` reads `[x,y,z,b]`. For a multi-channel Time-Frequency map (`chan×freq×time`) the **observed** TFCE is computed with `type 3`, but the **H0 (null)** section used `type 2` (lines 289, 303) — so the null misreads *time as the bootstrap dimension* and TFCE-enhances each time-slice independently, a different algorithm than the observed statistic. The corrected threshold is then incomparable and the TFCE-corrected p-values for F-effects in TF are wrong. The R² and t-value null sections already use the correct `2/1/3/2` map.

## Fix
```diff
- limo_tfce(1,squeeze(H0_Fval(:,:,:,1,b)),neighbouring_matrix,0);   % single-channel TF
+ limo_tfce(2,squeeze(H0_Fval(:,:,:,1,b)),neighbouring_matrix,0);
- limo_tfce(2,squeeze(H0_Fval(:,:,:,1,b)),neighbouring_matrix,0);   % multi-channel TF
+ limo_tfce(3,squeeze(H0_Fval(:,:,:,1,b)),neighbouring_matrix,0);
```

## Impact
Affects TFCE-corrected inference for F-effects (conditions / interactions / covariates) in Time-Frequency analyses. R² and t-tests were already correct.

## Reproduction
```matlab
%% Reproduction — Critical #4: TF null TFCE built with the wrong dimensionality
% In limo_tfce, type 2 reads [x,y,b]=size(data) -- so a 3D chan x freq x time
% array is misread with TIME as the bootstrap dimension b, and TFCE is applied to
% each time slice independently. type 3 reads [x,y,z,b] and clusters in true 3D.
%
% For multi-channel Time-Frequency F-maps limo_tfce_handling computes the OBSERVED
% statistic with type 3 but (pre-fix) built the H0 null with type 2 -- a different
% algorithm -- so the corrected threshold is incomparable. This script shows the
% two give materially different scores on a map with a cluster that spans time.
%
% Run from the limo_tools root.

rng(3);
nchan = 8; nfreq = 10; ntime = 12;

% a coherent positive blob spanning channels x freq x time (a real TF cluster)
[cc,ff,tt] = ndgrid(1:nchan,1:nfreq,1:ntime);
Fmap = 6*exp(-(((cc-4).^2)/5 + ((ff-5).^2)/6 + ((tt-6).^2)/9)) + 0.15*abs(randn(nchan,nfreq,ntime));

% channel neighbourhood, n_chan x n_chan logical. limo_tfce calls
% limo_findcluster with minnbchan=2, so a point needs >=2 active channel
% neighbours to survive -- use a dense montage (all channels neighbours) so the
% clustering is well-posed for this small synthetic example.
nb = true(nchan) & ~eye(nchan);

s3 = limo_tfce(3, Fmap, nb, 0);   % correct: matches the observed statistic (and the fixed null)
s2 = limo_tfce(2, Fmap, nb, 0);   % the buggy null: treats time as bootstraps -> per-slice 2D TFCE

d   = max(abs(s3(:)-s2(:)));
rel = d / max(abs(s3(:)));
fprintf('max TFCE score:  type3 (correct) = %.3f   type2 (buggy null) = %.3f\n', max(s3(:)), max(s2(:)));
fprintf('max |type3 - type2| = %.4g   (%.1f%% of the peak)\n', d, 100*rel);
assert(d > 1e-6, 'the buggy null (type 2) differs from the observed statistic (type 3)');
disp('PASS: type-2 null is not comparable to the type-3 observed statistic -> fix required.');
```

## Verification
Run under **MATLAB R2025a** from the repo root with the fix applied:
```
max TFCE score:  type3 (correct) = 184.079   type2 (buggy null) = 113.668
max |type3 - type2| = 81.97   (44.5% of the peak)
PASS: type-2 null is not comparable to the type-3 observed statistic -> fix required.
```

_Part of a broader Opus 4.8 multi-agent review of v4.2.1 — full report: https://devon7y.github.io/limo-opus-bug-review/_